### PR TITLE
[for discussion] add task wrapper and resolve_args functionality

### DIFF
--- a/brigade/core/helpers/__init__.py
+++ b/brigade/core/helpers/__init__.py
@@ -7,6 +7,13 @@ def merge_two_dicts(x, y):
     return z
 
 
-def format_string(text, task, **kwargs):
-    return text.format(host=task.host,
-                       **merge_two_dicts(task.host.items(), kwargs))
+def format_object(obj, host, **kwargs):
+    if isinstance(obj, dict):
+        return {format_object(k, host, **kwargs): format_object(v, host, **kwargs)
+                for k, v in obj.items()}
+    elif any([isinstance(obj, t) for t in [list, set]]):
+        return [format_object(e, host, **kwargs) for e in obj]
+    elif isinstance(obj, str):
+        return obj.format(**merge_two_dicts(host.items(), kwargs))
+    else:
+        return obj

--- a/brigade/core/task.py
+++ b/brigade/core/task.py
@@ -1,6 +1,22 @@
 from builtins import super
+from functools import wraps
 
 from brigade.core.exceptions import BrigadeExecutionError
+from brigade.core.helpers import format_object
+
+
+def task(resolve_args=None):
+    def real_decorator(func):
+        @wraps(func)
+        def wrapper(task=None, **kwargs):
+            if task:
+                for arg in resolve_args:
+                    kwargs[arg] = format_object(kwargs[arg], task.host)
+
+            result = func(task=task, **kwargs)
+            return result
+        return wrapper
+    return real_decorator
 
 
 class Task(object):

--- a/brigade/plugins/tasks/commands/command.py
+++ b/brigade/plugins/tasks/commands/command.py
@@ -3,16 +3,16 @@ import subprocess
 
 
 from brigade.core.exceptions import CommandError
-from brigade.core.helpers import format_string
-from brigade.core.task import Result
+from brigade.core.task import Result, task
 
 
+@task(resolve_args=["command"])
 def command(task, command):
     """
     Executes a command locally
 
     Arguments:
-        command (``str``): command to execute
+        command (``str``): (resolved) command to execute
 
     Returns:
         :obj:`brigade.core.task.Result`:
@@ -22,7 +22,6 @@ def command(task, command):
     Raises:
         :obj:`brigade.core.exceptions.CommandError`: when there is a command error
     """
-    command = format_string(command, task, **task.host)
     cmd = subprocess.Popen(shlex.split(command),
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE,

--- a/brigade/plugins/tasks/commands/remote_command.py
+++ b/brigade/plugins/tasks/commands/remote_command.py
@@ -1,13 +1,14 @@
 from brigade.core.exceptions import CommandError
-from brigade.core.task import Result
+from brigade.core.task import Result, task
 
 
+@task(resolve_args=["command"])
 def remote_command(task, command):
     """
     Executes a command locally
 
     Arguments:
-        command (``str``): command to execute
+        command (``str``): (resolved) command to execute
 
     Returns:
         :obj:`brigade.core.task.Result`:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'brigade'
-copyright = '2017, David Barroso'
+copyright = '2018, David Barroso'
 author = 'David Barroso'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/tests/core/test_format_object.py
+++ b/tests/core/test_format_object.py
@@ -1,0 +1,44 @@
+from brigade.core.helpers import format_object
+
+
+kwargs = {
+    "extra_key1": "extra_value1",
+}
+
+
+class Test(object):
+
+    def test_format_object_string(self, brigade):
+        host = brigade.inventory.hosts["dev1.group_1"]
+        obj = "{name} - {my_var} - {extra_key1}"
+        result = format_object(obj, host, **kwargs)
+        assert result == "dev1.group_1 - comes_from_dev1.group_1 - extra_value1"
+
+    def test_format_object_list(self, brigade):
+        host = brigade.inventory.hosts["dev1.group_1"]
+        obj = [1, "asdasd", "{name}", "{my_var}", "{extra_key1}"]
+        result = format_object(obj, host, **kwargs)
+        assert result == [1, "asdasd", "dev1.group_1", "comes_from_dev1.group_1", "extra_value1"]
+
+    def test_format_object_dict(self, brigade):
+        host = brigade.inventory.hosts["dev1.group_1"]
+        obj = {
+            1: "asdasd",
+            "{name}": "{my_var}",
+            "test": "{extra_key1}"
+        }
+        result = format_object(obj, host, **kwargs)
+        assert result == {1: 'asdasd', 'dev1.group_1': 'comes_from_dev1.group_1',
+                          'test': 'extra_value1'}
+
+    def test_format_object_complex(self, brigade):
+        host = brigade.inventory.hosts["dev1.group_1"]
+        obj = {
+            1: ["{name}", {"{name}": "test"}],
+            "{name}": "{my_var}",
+            "test": "{extra_key1}"
+        }
+        result = format_object(obj, host, **kwargs)
+        assert result == {1: ['dev1.group_1', {'dev1.group_1': 'test'}],
+                          'dev1.group_1': 'comes_from_dev1.group_1',
+                          'test': 'extra_value1'}

--- a/tests/plugins/tasks/commands/test_command.py
+++ b/tests/plugins/tasks/commands/test_command.py
@@ -6,7 +6,7 @@ class Test(object):
 
     def test_command(self, brigade):
         result = brigade.run(commands.command,
-                             command="echo {host.name}")
+                             command="echo {name}")
         assert result
         for h, r in result.items():
             assert h == r.stdout.strip()


### PR DESCRIPTION
Two things I'd like to discuss here:

1. Adding an optional wrapper where we can put some common logic for tasks. This common logic could have things like resolving arguments. For instance: https://github.com/brigade-automation/brigade/compare/task_wrapper?expand=1#diff-dbc265077515c480e1d473ace71d98b4R9
2. Do we want to resolve arguments automatically like we do in some places? I think @ktbyers doesn't really like it and I am starting to agree with him and we should probably remove it. The reason why I don't like it it's because it's not consistent between tasks and subtasks. for instance:

```
brigade.run(commands.command,
                    command="echo {name}") 
```

while most likely in a subtask you'd end up doing something like:

```
def my_subtask(task):
    task.run(commands.command,
             command=f"echo {task.host.name}") 
```

or:

```
def my_subtask(task):
    task.run(commands.command,
             command="echo {host.name}".format(host=task.host)) 
```

In any case, I think I'd rather encourage people to group tasks instead of running tasks in the main thread so I vote to remove the automatic resolver. In which case the wrapper can be scrapped or decide if we want to use it for something else. For instance, to "capture" non-`Result` objects and wrap them for consistency. For instance:

```
def my_subtask(task):
    ...
    return "YASSSSS!"


result = b.run(my_subtask)
print(result[my_host][0].result)  # this sould print "YASSSS!"
```