### PR TITLE
Move dry_run logic to the task

### DIFF
--- a/brigade/plugins/tasks/files/write_file.py
+++ b/brigade/plugins/tasks/files/write_file.py
@@ -25,11 +25,12 @@ def _generate_diff(filename, content, append):
     return "\n".join(diff)
 
 
-def write_file(task, filename, content, append=False):
+def write_file(task, filename, content, append=False, dry_run=None):
     """
     Write contents to a file (locally)
 
     Arguments:
+        dry_run (bool): Whether to apply changes or not
         filename (``str``): file you want to write into
         conteint (``str``): content you want to write
         append (``bool``): whether you want to replace the contents or append to it
@@ -40,7 +41,7 @@ def write_file(task, filename, content, append=False):
     """
     diff = _generate_diff(filename, content, append)
 
-    if not task.dry_run:
+    if not task.is_dry_run(dry_run):
         mode = "a+" if append else "w+"
         with open(filename, mode=mode) as f:
             f.write(content)

--- a/brigade/plugins/tasks/networking/napalm_configure.py
+++ b/brigade/plugins/tasks/networking/napalm_configure.py
@@ -2,12 +2,14 @@ from brigade.core.helpers import format_string
 from brigade.core.task import Result
 
 
-def napalm_configure(task, filename=None, configuration=None, replace=False):
+def napalm_configure(task, dry_run=None, filename=None, configuration=None, replace=False):
     """
     Loads configuration into a network devices using napalm
 
     Arguments:
+        dry_run (bool): Whether to apply changes or not
         configuration (str): configuration to load into the device
+        filename (str): filename containing the configuration to load into the device
         replace (bool): whether to replace or merge the configuration
 
     Returns:
@@ -24,7 +26,8 @@ def napalm_configure(task, filename=None, configuration=None, replace=False):
         device.load_merge_candidate(filename=filename, config=configuration)
     diff = device.compare_config()
 
-    if not task.dry_run and diff:
+    dry_run = task.is_dry_run(dry_run)
+    if not dry_run and diff:
         device.commit_config()
     else:
         device.discard_config()


### PR DESCRIPTION
The purpose of this is two-fold:

1. Simplify dry_run logic by moving it to the task directly.
2. Make it clearer which tasks support "dry_run" or not

By removing the `dry_run` logic from the core and transferring it to the tasks we basically get rid of code which only purpose is to move things around and we also make it clearer which tasks support it as now to override argument is part of the task signature.