### PR TITLE
Rename TestInventory to StringInventory

### DIFF
--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -1,6 +1,7 @@
 import os
-
 from builtins import super
+
+
 from brigade.core import InitBrigade
 from brigade.core.inventory import Inventory
 
@@ -12,7 +13,7 @@ def transform_func(host):
     host.processed_by_transform_function = True
 
 
-class TestInventory(Inventory):
+class StringInventory(Inventory):
 
     def __init__(self, *args, **kwargs):
         hosts = {"host1": {}, "host2": {}}
@@ -62,15 +63,15 @@ class Test(object):
 
     def test_InitBrigade_different_inventory_by_string(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
-                          inventory="tests.core.test_InitBrigade.TestInventory",
+                          inventory="tests.core.test_InitBrigade.StringInventory",
                           )
-        assert isinstance(brg.inventory, TestInventory)
+        assert isinstance(brg.inventory, StringInventory)
 
     def test_InitBrigade_different_inventory_imported(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
-                          inventory=TestInventory,
+                          inventory=StringInventory,
                           )
-        assert isinstance(brg.inventory, TestInventory)
+        assert isinstance(brg.inventory, StringInventory)
 
     def test_InitBrigade_different_transform_function_by_string(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),


### PR DESCRIPTION
Pytest is raising a warning because the name of the Inventory class
within the tests. This fix renames the class to remove the warning:

========= warnings summary ===========================
tests/core/test_InitBrigade.py::TestInventory
  cannot collect test class 'TestInventory' because it has a __init__ constructor

-- Docs: http://doc.pytest.org/en/latest/warnings.html

============== 78 passed, 92 skipped, 1 warnings in 65.69 seconds ====