### PR TITLE
Fix setup.py in preparation for pip10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,8 @@
 #!/usr/bin/env python
-import uuid
+from setuptools import find_packages, setup
 
-try:
-    from setuptools import find_packages, setup
-except ImportError:
-    from distutils.core import setup
-
-from pip.req import parse_requirements
-
-install_reqs = parse_requirements("requirements.txt", session=uuid.uuid1())
-reqs = [str(ir.req) for ir in install_reqs]
-
+with open('requirements.txt', 'r') as fs:
+    reqs = [r for r in fs.read().splitlines() if (len(r) > 0 and not r.startswith("#"))]
 
 __author__ = "dbarrosop@dravetech.com"
 __license__ = "Apache License, version 2"


### PR DESCRIPTION
To avoid upcoming problems with pip 10. Could perhaps add more controls, but I think this would basically be enough.

The other easy alternative would be to get rid of requirements.txt

Remove:
```python
try:
    from setuptools import find_packages, setup
except ImportError:
    from distutils.core import setup
```

As `find_packages` is used regardless later in the script this section didn't make sense.