### PR TITLE
add mechanism to pass jinja_filters

### DIFF
--- a/brigade/core/helpers/jinja_helper.py
+++ b/brigade/core/helpers/jinja_helper.py
@@ -1,16 +1,19 @@
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 
-def render_from_file(path, template, **kwargs):
+def render_from_file(path, template, jinja_filters=None, **kwargs):
+    jinja_filters = jinja_filters or {}
     env = Environment(
         loader=FileSystemLoader(path), undefined=StrictUndefined, trim_blocks=True
     )
-    #  env.filters.update(jinja_filters.filters())
+    env.filters.update(jinja_filters)
     template = env.get_template(template)
     return template.render(**kwargs)
 
 
-def render_from_string(template, **kwargs):
+def render_from_string(template, jinja_filters=None, **kwargs):
+    jinja_filters = jinja_filters or {}
     env = Environment(undefined=StrictUndefined, trim_blocks=True)
+    env.filters.update(jinja_filters)
     template = env.from_string(template)
     return template.render(**kwargs)

--- a/brigade/plugins/tasks/text/template_file.py
+++ b/brigade/plugins/tasks/text/template_file.py
@@ -2,23 +2,29 @@ from brigade.core.helpers import format_string, jinja_helper, merge_two_dicts
 from brigade.core.task import Result
 
 
-def template_file(task, template, path, **kwargs):
+def template_file(task, template, path, jinja_filters=None, **kwargs):
     """
     Renders contants of a file with jinja2. All the host data is available in the tempalte
 
     Arguments:
         template (string): filename
         path (string): path to dir with templates (will be rendered with format)
+        jinja_filters (dict): jinja filters to enable. Defaults to brigade.config.jinja_filters
         **kwargs: additional data to pass to the template
 
     Returns:
         :obj:`brigade.core.task.Result`:
             * result (``string``): rendered string
     """
+    jinja_filters = jinja_filters or {} or task.brigade.config.jinja_filters
     merged = merge_two_dicts(task.host, kwargs)
     path = format_string(path, task, **kwargs)
     template = format_string(template, task, **kwargs)
     text = jinja_helper.render_from_file(
-        template=template, path=path, host=task.host, **merged
+        template=template,
+        path=path,
+        host=task.host,
+        jinja_filters=jinja_filters,
+        **merged
     )
     return Result(host=task.host, result=text)

--- a/brigade/plugins/tasks/text/template_string.py
+++ b/brigade/plugins/tasks/text/template_string.py
@@ -2,18 +2,22 @@ from brigade.core.helpers import jinja_helper, merge_two_dicts
 from brigade.core.task import Result
 
 
-def template_string(task, template, **kwargs):
+def template_string(task, template, jinja_filters=None, **kwargs):
     """
     Renders a string with jinja2. All the host data is available in the tempalte
 
     Arguments:
         template (string): template string
+        jinja_filters (dict): jinja filters to enable. Defaults to brigade.config.jinja_filters
         **kwargs: additional data to pass to the template
 
     Returns:
         :obj:`brigade.core.task.Result`:
             * result (``string``): rendered string
     """
+    jinja_filters = jinja_filters or {} or task.brigade.config.jinja_filters
     merged = merge_two_dicts(task.host, kwargs)
-    text = jinja_helper.render_from_string(template=template, host=task.host, **merged)
+    text = jinja_helper.render_from_string(
+        template=template, host=task.host, jinja_filters=jinja_filters, **merged
+    )
     return Result(host=task.host, result=text)


### PR DESCRIPTION
For instance:

```
# jinja_filters/__init__.py

def get_filters():
    return {"test": test}


def test(data):
    return "yes!!!"
```

and then:

```
    brg = InitBrigade(
        dry_run=dry_run,
        SimpleInventory={"host_file": HOSTS_FILE, "group_file": GROUPS_FILE},
        jinja_filters="jinja_filters.get_filters",
    )
```