### PR TITLE
Add result key and cleanup

### DIFF
--- a/brigade/plugins/functions/text/__init__.py
+++ b/brigade/plugins/functions/text/__init__.py
@@ -69,10 +69,6 @@ def print_result(
     Returns:
         :obj:`brigade.core.task.Result`:
     """
-    #  def print_aggregated_result(host, result):
-    #      title = "" if result.changed is None else " ** changed : {} ".format(host_data.changed)
-    #      msg = "* {}{}".format(host, title)
-    #      print("{}{}{}{}".format(Style.BRIGHT, color, msg, "*" * (80 - len(msg))))
 
     vars = vars or ["diff", "result", "stdout"]
     if isinstance(vars, str):

--- a/brigade/plugins/tasks/commands/remote_command.py
+++ b/brigade/plugins/tasks/commands/remote_command.py
@@ -11,6 +11,7 @@ def remote_command(task, command):
 
     Returns:
         :obj:`brigade.core.task.Result`:
+          * result (``str``): stderr or stdout
           * stdout (``str``): stdout
           * stderr (``srr``): stderr
 
@@ -32,4 +33,5 @@ def remote_command(task, command):
     if exit_status_code:
         raise CommandError(command, exit_status_code, stdout, stderr)
 
-    return Result(host=task.host, stderr=stderr, stdout=stdout)
+    result = stderr if stderr else stdout
+    return Result(result=result, host=task.host, stderr=stderr, stdout=stdout)

--- a/brigade/plugins/tasks/networking/tcp_ping.py
+++ b/brigade/plugins/tasks/networking/tcp_ping.py
@@ -17,7 +17,7 @@ def tcp_ping(task, ports, timeout=2, host=None):
 
     Returns:
         :obj:`brigade.core.task.Result`:
-          * tcp_port (``dict``): Contains port numbers as keys with True/False as values
+          * result (``dict``): Contains port numbers as keys with True/False as values
     """
 
     if isinstance(ports, int):
@@ -48,4 +48,4 @@ def tcp_ping(task, ports, timeout=2, host=None):
             s.close()
         result[port] = connection
 
-    return Result(host=task.host, tcp_port=result)
+    return Result(host=task.host, result=result)

--- a/tests/plugins/tasks/networking/test_tcp_ping.py
+++ b/tests/plugins/tasks/networking/test_tcp_ping.py
@@ -18,7 +18,7 @@ class Test(object):
 
         assert result
         for h, r in result.items():
-            assert r.tcp_port[65004]
+            assert r.result[65004]
 
     def test_tcp_ping_ports(self, brigade):
         filter = brigade.filter(name="dev4.group_2")
@@ -26,8 +26,8 @@ class Test(object):
 
         assert result
         for h, r in result.items():
-            assert r.tcp_port[35004] is False
-            assert r.tcp_port[65004]
+            assert r.result[35004] is False
+            assert r.result[65004]
 
     def test_tcp_ping_invalid_port(self, brigade):
         results = brigade.run(networking.tcp_ping, ports="web")
@@ -55,8 +55,8 @@ def test_tcp_ping_external_hosts():
     assert result
     for h, r in result.items():
         if h == "www.github.com":
-            assert r.tcp_port[23] is False
-            assert r.tcp_port[443]
+            assert r.result[23] is False
+            assert r.result[443]
         else:
-            assert r.tcp_port[23] is False
-            assert r.tcp_port[443] is False
+            assert r.result[23] is False
+            assert r.result[443] is False


### PR DESCRIPTION
Should we also add / change other plugins to always have the most important output in "result"?

Don't know if that would be diff or changed in something like napalm_configure().