### PR TITLE
Add description to package for display on pypi.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include requirements*
+include README.md

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ While we are happy to help, the [GitHub issues](<https://github.com/brigade-auto
 Contributing to Brigade
 =======================
 
-If you want to help the project, the [Contribution Guidelines](CONTRIBUTING.rst) is the best place to start.
+If you want to help the project, the [Contribution Guidelines](https://brigade.readthedocs.io/en/develop/contributing/index.html) is the best place to start.

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ from setuptools import find_packages, setup
 with open("requirements.txt", "r") as fs:
     reqs = [r for r in fs.read().splitlines() if (len(r) > 0 and not r.startswith("#"))]
 
+with open("README.md", "r") as fs:
+    long_description = fs.read()
+
 __author__ = "dbarrosop@dravetech.com"
 __license__ = "Apache License, version 2"
 
@@ -13,6 +16,8 @@ setup(
     name="brigade",
     version=__version__,
     description="Fighting fire with fire",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author=__author__,
     url="https://github.com/brigade-automation/brigade",
     include_package_data=True,


### PR DESCRIPTION
With today's launch of the new pypi we can now have markdown files to describe the project. Currently Brigade doesn't have a description on https://pypi.org/project/brigade/, this will add the README.md to the package so that it can be displayed on the pypi page.