### PR TITLE
dont mask error when running a grouped task

### DIFF
--- a/brigade/core/task.py
+++ b/brigade/core/task.py
@@ -93,6 +93,10 @@ class Task(object):
         if "severity" not in kwargs:
             kwargs["severity"] = self.severity
         r = Task(task, **kwargs).start(self.host, self.brigade)
+        if r.failed:
+            # Without this we will keep running the grouped task
+            raise r.exception
+
         self.results.append(r[0] if len(r) == 1 else r)
         return r
 

--- a/tests/core/test_tasks.py
+++ b/tests/core/test_tasks.py
@@ -93,8 +93,7 @@ class Test(object):
         r = brigade.run(task_fails_for_some, severity=logging.WARN, num_workers=1)
         for host, result in r.items():
             if host == "dev3.group_2":
-                assert result[0].severity == logging.WARN
-                assert result[1].severity == logging.ERROR
+                assert result[0].severity == logging.ERROR
             else:
                 assert result[0].severity == logging.WARN
                 assert result[1].severity == logging.DEBUG


### PR DESCRIPTION
Without this a grouped task with a failing task won't stop and will keep running the rest of the tasks in the same group. For instance:

```
def grouped_tasks(task):
     task.run(task=this_task_fails)
     task.run(task=another_task)

brigade.run(task=grouped_tasks)
```

Without this patch `another_task` will run even if `this_task_fails`. With this patch, you have to catch if if you want to keep going.