### PR TITLE
Add test for has_parent_group()

### DIFF
--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -196,3 +196,11 @@ class Test(object):
         assert (
             inventory.hosts["dev4.group_2"].data["my_var"] == "comes_from_dev4.group_2"
         )
+
+    def test_has_parents(self):
+        assert inventory.hosts["dev1.group_1"].has_parent_group(
+            inventory.groups["group_1"]
+        )
+        assert not inventory.hosts["dev1.group_1"].has_parent_group(
+            inventory.groups["group_2"]
+        )


### PR DESCRIPTION
The documentation states that the has_parent_group takes an object as
its argument. Don't know if it would be better with just a string or if
it's better the way it is now?