### PR TITLE
NAPALM connection fallback to ssh_port if no optional_args and no API port defined

### DIFF
--- a/brigade/plugins/tasks/connections/napalm_connection.py
+++ b/brigade/plugins/tasks/connections/napalm_connection.py
@@ -25,6 +25,8 @@ def napalm_connection(task=None, timeout=60, optional_args=None):
     }
     if "port" not in parameters["optional_args"] and host.network_api_port:
         parameters["optional_args"]["port"] = host.network_api_port
+    elif "port" not in parameters["optional_args"] and host.ssh_port:
+        parameters["optional_args"]["port"] = host.ssh_port
     network_driver = get_network_driver(host.nos)
 
     host.connections["napalm"] = network_driver(**parameters)


### PR DESCRIPTION
For Cisco IOS and for NXOS_SSH, Brigade user's might logically define a `brigade_ssh_port` in inventory.

Consequently, I think it is logical that we should process them in this order:

1. optional_args['port']
2. brigade_network_api_port
3. brigade_ssh_port


